### PR TITLE
Fixed `cctl off` CLI showing "turned on" bots.

### DIFF
--- a/src/cctl/cli/__init__.py
+++ b/src/cctl/cli/__init__.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 
-"""This package exposes the CLI interface for cctl."""
+"""This package exposes the CLI interface for cctl.
+
+If you are attempting to modify the commands and/or add/delete a new command,
+please see the ``cctl.cli.commands`` module.
+"""
 
 import argparse
 from argparse import ArgumentParser, Namespace

--- a/src/cctl/cli/commands.py
+++ b/src/cctl/cli/commands.py
@@ -105,7 +105,7 @@ async def _boot_bot(args: Namespace, config: Configuration, on: bool) -> int:
     grouped_by_err = itertools.groupby(
             group_els(results, key=lambda x: x[1]), lambda x: x[1])
     return _output_errors_for_bots([(k, list(v)) for k, v in grouped_by_err],
-                                   'turning on')
+                                   f'turning {"on" if on else "off"}')
 
 
 @cctl_command('on', arguments=[


### PR DESCRIPTION
Closes #88 .