### PR TITLE
Added a Helpful Message Indicating the Default Value for Bot ID targets in CLI

### DIFF
--- a/src/cctl/cli/commands.py
+++ b/src/cctl/cli/commands.py
@@ -121,7 +121,6 @@ async def on_handle(args: Namespace, config: Configuration) -> int:
     """Boot a range of robots up."""
     if len(args.id) == 0:
         args.id = ['all']
-        return 0
 
     return await _boot_bot(args, config, True)
 
@@ -138,7 +137,6 @@ async def off_handle(args: Namespace, config: Configuration) -> int:
     """Boot a range of robots down."""
     if len(args.id) == 0:
         args.id = ['all']
-        return 0
 
     return await _boot_bot(args, config, False)
 


### PR DESCRIPTION
Resolves #89 

## Validation Task

Please ensure this makes sense. Run `cctl {on,off} -h` and `cctl {start,pause} -h`.